### PR TITLE
Add 'seconds' to output

### DIFF
--- a/django_sqlprint_middleware/django_sqlprint_middleware.py
+++ b/django_sqlprint_middleware/django_sqlprint_middleware.py
@@ -53,9 +53,9 @@ class SqlPrintMiddleware(Parent):
 
         totsecs = 0.0
         for query in queries:
-            print(query['time'], 'used on:')
+            print(query['time'], 'seconds used on:')
             totsecs += float(query['time'])
             print(highlight(query['sql'], lexer, formatters.TerminalFormatter()))
 
         print('Number of queries:', len(queries))
-        print('Total time:', totsecs)
+        print('Total time:', totsecs, 'seconds')


### PR DESCRIPTION
Add seconds to output so we know what the unit is. People might not know if it is seconds or milliseconds since many database tools report query execution time in milliseconds.